### PR TITLE
Get input/output variable names with vector<string>

### DIFF
--- a/bmi.hxx
+++ b/bmi.hxx
@@ -20,8 +20,8 @@ namespace bmi {
       virtual std::string GetComponentName() = 0;
       virtual int GetInputItemCount() = 0;
       virtual int GetOutputItemCount() = 0;
-      virtual void GetInputVarNames(char **names) = 0;
-      virtual void GetOutputVarNames(char **names) = 0;
+      virtual void GetInputVarNames(std::vector<std::string>&) = 0;
+      virtual void GetOutputVarNames(std::vector<std::string>&) = 0;
 
       // Variable information functions
       virtual int GetVarGrid(std::string name) = 0;

--- a/bmi.hxx
+++ b/bmi.hxx
@@ -20,8 +20,8 @@ namespace bmi {
       virtual std::string GetComponentName() = 0;
       virtual int GetInputItemCount() = 0;
       virtual int GetOutputItemCount() = 0;
-      virtual void GetInputVarNames(std::vector<std::string>&) = 0;
-      virtual void GetOutputVarNames(std::vector<std::string>&) = 0;
+      virtual std::vector<std::string> GetInputVarNames() = 0;
+      virtual std::vector<std::string> GetOutputVarNames() = 0;
 
       // Variable information functions
       virtual int GetVarGrid(std::string name) = 0;


### PR DESCRIPTION
This PR changes the signatures of the GetInputVarNames and GetOutputVarNames methods. Instead of passing a `char**` parameter to store the names, a `vector<string>` is returned. The advantages to this technique are:

* A vector is a standard container in the C++ standard library.
* It simplifies the implementation: easier-to-read code, no `strncpy` calls.

A criticism of this technique is that the vector is created inside the BMI method. However, this is analogous the use of Tuple in these same methods in the Python BMI.

Another criticism is that vector is a higher-level language construct. However, it's probably more natural for a C++ programmer to use it than a char**.