### PR TITLE
Update build and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,25 +25,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          auto-update-conda: true
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
+          micromamba-version: latest
+          environment-name: testing
+          init-shell: >-
+            bash
+            powershell
+          create-args: >-
+            make
+            cmake
+            cxx-compiler
+            pkg-config
 
-      - name: Show conda installation info
-        run: conda info
-
-      - name: Install build tools and dependencies into env
-        run: |
-          mamba install make cmake cxx-compiler pkg-config
-          mamba list
-
-      - name: Make cmake build directory
+      - name: Make CMake build directory
         run: cmake -E make_directory build
 
-      - name: Configure cmake (unix)
+      - name: Configure cmake (Unix)
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         working-directory: ${{ github.workspace }}/build
         run: |
@@ -51,22 +49,30 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
           -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
 
-      - name: Configure cmake (windows)
+      - name: Configure CMake (windows)
         if: matrix.os == 'windows-latest'
         working-directory: ${{ github.workspace }}\build
         shell: pwsh
         run: |
-          & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" x86
+          & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" x86
 
           cmake .. `
-            -DCMAKE_INSTALL_PREFIX:PATH=$env:CONDA_PREFIX `
+            -DCMAKE_INSTALL_PREFIX:PATH=$env:CONDA_PREFIX\Library `
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
 
       - name: Build
         working-directory: ${{ github.workspace }}/build
         run: cmake --build . --target install --config ${{ matrix.build-type }}
 
-      - name: Test
+      - name: Test (Unix)
+        if: matrix.os != 'windows-latest'
         run: |
           test -f $CONDA_PREFIX/include/bmi.hxx
           test -f $CONDA_PREFIX/lib/pkgconfig/bmicxx.pc
+
+      - name: Test (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\Library\include\bmi.hxx ) ){ exit 1 }
+          if ( -not ( Test-Path -Path $env:CONDA_PREFIX\Library\lib\pkgconfig\bmicxx.pc ) ){ exit 1 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         build-type: [Release]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: mamba-org/setup-micromamba@v1
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,18 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 
-project(bmicxx CXX)
+project(bmicxx LANGUAGES CXX)
 
 set(BMI_VERSION 2.0)
+include(GNUInstallDirs)
 
 configure_file(${CMAKE_SOURCE_DIR}/${CMAKE_PROJECT_NAME}.pc.cmake
   ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.pc)
 
 install(
   FILES bmi.hxx
-  DESTINATION include
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 install(
   FILES ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.pc
-  DESTINATION lib/pkgconfig
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # bmi-cxx
 
 C++ bindings for the CSDMS
-[Basic Model Interface](https://bmi-spec.readthedocs.io).
+[Basic Model Interface](https://bmi.readthedocs.io).
 
 
 ## Build/Install
@@ -37,6 +37,8 @@ To install the C++ BMI bindings from source with cmake, run
 
 where `<path-to-installation>` is the base directory
 in which to install the bindings (`/usr/local` is the default).
+When using a conda environment,
+use the `$CONDA_PREFIX` environment variable.
 
 The installation will look like:
 
@@ -65,10 +67,10 @@ run the following in a [Developer Command Prompt](https://docs.microsoft.com/en-
 	  -DCMAKE_BUILD_TYPE=Release
 	cmake --build . --target install --config Release
 
-where `<path-to-installation>` is the base directory
-in which to install the bindings (`"C:\Program Files (x86)"` is the default;
-note that quotes and an absolute path are needed).
-
+where `<path-to-installation>` is the base directory in which to install the bindings.
+The default is `"C:\Program Files (x86)"`.
+Note that quotes and an absolute path are needed.
+When using a conda environment, use `"%CONDA_PREFIX%\Library"`.
 
 ## Use
 

--- a/bmicxx.pc.cmake
+++ b/bmicxx.pc.cmake
@@ -1,5 +1,5 @@
 Name: Bmi
 Description: The Basic Model Interface
 Version: ${BMI_VERSION}
-Libs: -L${CMAKE_INSTALL_PREFIX}/lib -lbmicxx
-Cflags: -I${CMAKE_INSTALL_PREFIX}/include
+Libs: -L${CMAKE_INSTALL_LIBDIR} -lbmicxx
+Cflags: -I${CMAKE_INSTALL_INCLUDEDIR}


### PR DESCRIPTION
The CMake build process and the GitHub Actions CI workflow were outdated. This PR updates them. Compare with https://github.com/csdms/bmi-c/pull/7 and https://github.com/csdms/bmi-c/pull/8.