### PR TITLE
Add virtual destructor

### DIFF
--- a/bmi.hxx
+++ b/bmi.hxx
@@ -19,6 +19,8 @@ namespace bmi {
 
   class Bmi {
     public:
+      virtual ~Bmi() { }
+
       // Model control functions.
       virtual void Initialize(std::string config_file) = 0;
       virtual void Update() = 0;


### PR DESCRIPTION
The Bmi base class definition needs to define its destructor as `virtual` to enable derived classes to support accurate destruction.

Cf https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-dtor

This is technically an ABI change impacting any existing code. To avoid potential failures and definite UB from ODR violation, all clients and implementations within a given system will need to be (re-) built against matching versions of this header.

It's unclear whether it's a breaking change of the BMI specification itself. The depends on whether the reference to this file is normative or exemplary.

Resolves #11